### PR TITLE
Add next event to user dashboard

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -2,5 +2,6 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def show
+    @events = Event.future
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,2 +1,7 @@
 class Event < ApplicationRecord
+  validates :date_on, presence: true
+
+  def self.future
+    where("date_on > ?", DateTime.now)
+  end
 end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,3 +1,9 @@
-<h1>Dashboard page!</h1>
+<h1>Dashboard</h1>
+<h2>Next events</h2>
+
+<% @events.each do |event| %>
+  <p class="event"><%= event.date_on %></p>
+<% end %>
+
 
 <%= link_to "Sign out", destroy_user_session_path, method: :delete %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
       date_on DateTime.yesterday
     end
   end
-  
+
   factory :user do
     email "user@email.com"
     password "password"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,18 @@
 FactoryGirl.define do
   factory :event do
     date_on "2016-05-29 09:32:14"
+
+    trait :future do
+      date_on DateTime.tomorrow
+    end
+
+    trait :past do
+      date_on DateTime.yesterday
+    end
   end
+  
   factory :user do
+    email "user@email.com"
+    password "password"
   end
 end

--- a/spec/features/users_manages_confirmations_to_events_spec.rb
+++ b/spec/features/users_manages_confirmations_to_events_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+feature "user manages confirmation to events" do
+  it "sees future events" do
+    event = create(:event, :future)
+    user = create(:user)
+
+    sign_in user
+    visit dashboard_path
+
+    expect(page).to have_css(".event", text: event.date_on)
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Event, type: :model do
-  it {is_expected.to validate_presence_of :date_on}
+  it { is_expected.to validate_presence_of :date_on }
 
   it "returns future events" do
     future = create(:event, :future)

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,5 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Event, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it {is_expected.to validate_presence_of :date_on}
+
+  it "returns future events" do
+    future = create(:event, :future)
+    create(:event, :past)
+
+    expect(Event.future).to eq [future]
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,7 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false
+  config.include Devise::Test::IntegrationHelpers, type: :feature
 end
 
 ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
This change adds the list of future events to user dashboard. Past
events are not shown in the dashboard for the moment.
